### PR TITLE
Fix: Add setuptools for warcio to work (pkg_resources not found)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 warcio
 cdx_toolkit
 cdxj-indexer


### PR DESCRIPTION
`warcio` imports `pkg_resources`, but it is not in system packages anymore. So we need to add setuptools as requirement.

```
make extract
"creating extraction.* from local warcs, the offset numbers are from the cdxj index"
warcio extract --payload whirlwind.warc.gz 1023 > extraction.html
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "T:\GITREPO\_CC\whirlwind-python\.venv\Scripts\warcio.exe\__main__.py", line 7, in <module>
  File "t:\GITREPO\_CC\whirlwind-python\.venv\Lib\site-packages\warcio\cli.py", line 16, in main
    parser.add_argument('-V', '--version', action='version', version=get_version())
                                                                     ^^^^^^^^^^^^^
  File "t:\GITREPO\_CC\whirlwind-python\.venv\Lib\site-packages\warcio\cli.py", line 60, in get_version
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
make: *** [Makefile:34: extract] Error 1
```
