### PR TITLE
Some updates after working through this on a local MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@ extraction.*
 testing.*
 whirlwind.parquet
 collinfo.json
+
+# Ignore virtual environment
+.venv/
+
+# Ignore VS Code settings
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
 venv:
-	@echo "making a venv in ~/venv/whirlwind"
-	mkdir -p ~/venv
-	virtualenv -p python ~/venv/whirlwind
+	@echo "making a venv in ./.venv"
+	python3 -m venv .venv
 	@echo
 	@echo "now you have to activate it:"
-	@echo ". ~/venv/whirlwind/bin/activate"
+	@echo "source .venv/bin/activate"
 	@echo
 
 install:
@@ -55,8 +54,15 @@ cdx_toolkit:
 	@echo
 
 download_collinfo:
-	@echo downloading collinfo.json so we can find out the crawl name
-	wget https://index.commoncrawl.org/collinfo.json
+	@echo "downloading collinfo.json so we can find out the crawl name"
+	@if command -v wget > /dev/null 2>&1; then \
+		wget https://index.commoncrawl.org/collinfo.json; \
+	elif command -v curl > /dev/null 2>&1; then \
+		curl -O https://index.commoncrawl.org/collinfo.json; \
+	else \
+		echo "Error: neither wget nor curl is installed."; \
+		exit 1; \
+	fi
 	sleep 5
 
 duck_local_files:

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ then here's the best choice:
 
 Run `make duck_s3_ls_then_cloudfront`
 
+**Note:** You need a valid AWS credentials to run this command.
+
 On a machine with a 1 gigabit network connection, and many cores, this takes 1
 minute total, and uses 8 cores.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Makefile, so it would be nice if you had "make" on your system.
 
 Ready? Here we go!
 
+## Notes for Mac OS
+
+```
+brew install virtualenv
+brew install awscli
+```
+
 ## Look at the example files in an editor
 
 warc files are a container that holds files, similar to zip and tar files.

--- a/duck.py
+++ b/duck.py
@@ -55,8 +55,11 @@ def get_files(algo, crawl):
         with open(file_file) as fd:
             files = fd.read().splitlines()
             files = [external_prefix+f.split()[3] for f in files]
+        if not files:
+            raise ValueError(f'{file_file} is empty')
+
     else:
-        raise NotImplementedError('algo: '+algo)
+        raise NotImplementedError(f'algo: {algo}')
     return files
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyarrow
 pandas
 polars
 cdxj-indexer
+setuptools


### PR DESCRIPTION
- more requirements for a pristine Python environment
- error case and note when the crawl index file is empty
- allow the use or `curl` or `wget`.  `curl` is installed by default on MacOS
- Optional - virtual environment changes that make a little more self contained?
   I'm fine with however you want to use venv but this change make the project instructions
   more self contained.


I was able to work through this completely

```
warning! this might take 1-10 minutes
python duck.py s3_ls_then_cloudfront
downloading index file list from s3
total records for crawl: CC-MAIN-2024-22
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│   2709877975 │
└──────────────┘

our one row
┌──────────────────────┬──────────────────────┬──────────────────┬───┬──────────────────┬─────────────────┬─────────┐
│     url_surtkey      │         url          │  url_host_name   │ … │   warc_segment   │      crawl      │ subset  │
│       varchar        │       varchar        │     varchar      │   │     varchar      │     varchar     │ varchar │
├──────────────────────┼──────────────────────┼──────────────────┼───┼──────────────────┼─────────────────┼─────────┤
│ org,wikipedia,an)/…  │ https://an.wikiped…  │ an.wikipedia.org │ … │ 1715971057216.39 │ CC-MAIN-2024-22 │ warc    │
├──────────────────────┴──────────────────────┴──────────────────┴───┴──────────────────┴─────────────────┴─────────┤
│ 1 rows                                                                                       32 columns (6 shown) │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

writing our one row to a local parquet file, whirlwind.parquet
total records for local whirlwind.parquet should be 1
┌──────────────┐
│ count_star() │
│    int64     │
├──────────────┤
│            1 │
└──────────────┘

our one row, locally
┌──────────────────────┬──────────────────────┬──────────────────┬───┬──────────────────┬─────────────────┬─────────┐
│     url_surtkey      │         url          │  url_host_name   │ … │   warc_segment   │      crawl      │ subset  │
│       varchar        │       varchar        │     varchar      │   │     varchar      │     varchar     │ varchar │
├──────────────────────┼──────────────────────┼──────────────────┼───┼──────────────────┼─────────────────┼─────────┤
│ org,wikipedia,an)/…  │ https://an.wikiped…  │ an.wikipedia.org │ … │ 1715971057216.39 │ CC-MAIN-2024-22 │ warc    │
├──────────────────────┴──────────────────────┴──────────────────┴───┴──────────────────┴─────────────────┴─────────┤
│ 1 rows                                                                                       32 columns (6 shown) │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

complete row:
  url_surtkey org,wikipedia,an)/wiki/escopete
  url https://an.wikipedia.org/wiki/Escopete
  url_host_name an.wikipedia.org
  url_host_tld org
  url_host_2nd_last_part wikipedia
  url_host_3rd_last_part an
  url_host_4th_last_part None
  url_host_5th_last_part None
  url_host_registry_suffix org
  url_host_registered_domain wikipedia.org
  url_host_private_suffix org
  url_host_private_domain wikipedia.org
  url_host_name_reversed org.wikipedia.an
  url_protocol https
  url_port nan
  url_path /wiki/Escopete
  url_query None
  fetch_time 2024-05-18 01:58:10+00:00
  fetch_status 200
  fetch_redirect None
  content_digest RY7PLBUFQNI2FFV5FTUQK72W6SNPXLQU
  content_mime_type text/html
  content_mime_detected text/html
  content_charset UTF-8
  content_languages spa
  content_truncated None
  warc_filename crawl-data/CC-MAIN-2024-22/segments/1715971057216.39/warc/CC-MAIN-20240517233122-20240518023122-00000.warc.gz
  warc_record_offset 80610731
  warc_record_length 17423
  warc_segment 1715971057216.39
  crawl CC-MAIN-2024-22
  subset warc

equivalent to cdxj:
org,wikipedia,an)/wiki/escopete 20240518015810 {"url": "https://an.wikipedia.org/wiki/Escopete", "mime": "text/html", "status": "200", "digest": "sha1:RY7PLBUFQNI2FFV5FTUQK72W6SNPXLQU", "length": "17423", "offset": "80610731", "filename": "crawl-data/CC-MAIN-2024-22/segments/1715971057216.39/warc/CC-MAIN-20240517233122-20240518023122-00000.warc.gz"}
```

