### PR TITLE
Updating requirements.txt to prevent make install errors (and add a missing dependency in some cases)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 warcio
 cdx_toolkit
 cdxj-indexer
+legacy-cgi ; python_version > "3.12"
 duckdb
 pyarrow
 pandas
 polars
 cdxj-indexer
 setuptools
-gzip
+gzip ; python_version < "2.5"


### PR DESCRIPTION
CGI got removed as a core library in py 3.12 so I included the legacy dependency for newer py envs.  GZIP is ancient it was added in 2.4 so likely could just be removed as a required module this commit makes it optional.