### PR TITLE
Expand the home directory path before searching for the local files

### DIFF
--- a/duck.py
+++ b/duck.py
@@ -24,7 +24,7 @@ def get_files(algo, crawl):
         files = f's3://commoncrawl/cc-index/table/cc-main/warc/crawl={crawl}/subset=warc/*.parquet'
         raise NotImplementedError('will cause a 403')
     elif algo == 'local_files':
-        files = f'~/commmoncrawl/cc-index/table/cc-main/warc/crawl={crawl}/subset=warc/*.parquet'
+        files = os.path.expanduser(f'~/commmoncrawl/cc-index/table/cc-main/warc/crawl={crawl}/subset=warc/*.parquet')
         files = glob.glob(files)
         # did we already download? we expect 300 files of about a gigabyte
         if len(files) < 250:


### PR DESCRIPTION
This PR updates the file path construction in the `duck.py` script to use `os.path.expanduser`. Previously, the file path was defined as a raw string containing the `~` symbol for the home directory. However, Python does not automatically expand the tilde (`~`) to the user's home directory in file paths. This can cause issues when trying to access files using such paths.

By using `os.path.expanduser`, the path is now properly expanded.