### PR TITLE
fix(CI): Drop EOL py3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,11 +15,11 @@ jobs:
       fail-fast: false
       max-parallel: 1  # avoids ever triggering a rate limit
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
         EXTRA: [false]  # used to force includes to get included
         include:
-          - python-version: '3.8'
+          - python-version: '3.9'
             # see https://github.com/duckdb/duckdb/blob/main/.github/workflows/Python.yml for duckdb python versions
             os: ubuntu-22.04  # oldest version on github actions
             EXTRA: true
@@ -29,7 +29,7 @@ jobs:
           - python-version: '3.13'
             os: macos-latest
             EXTRA: true
-          - python-version: '3.8'
+          - python-version: '3.9'
             os: windows-latest
             EXTRA: true
           - python-version: '3.13'


### PR DESCRIPTION
- drop EOL py3.8 from matrix tests with `ubuntu-latest`
- replace py3.8 with py3.9 for individual tests with `ubuntu-22.04` and `windows-latest`